### PR TITLE
Better as json

### DIFF
--- a/lib/requeue.rb
+++ b/lib/requeue.rb
@@ -2,38 +2,40 @@ require 'redis'
 
 module Requeue
   class Queue
-    def initialize(redis: Redis.current, prefix: 'queue', unique:true)
-      @prefix = prefix 
-      @unique = unique 
+    attr_reader :redis, :prefix, :unique
+
+    def initialize(redis: Redis.current, prefix: 'queue', unique: true)
+      @prefix = prefix
+      @unique = unique
       @redis  = redis
     end
 
     def name
-      "#{@prefix}:queue"
+      "#{prefix}:queue"
     end
 
-    def list 
-      @redis.lrange(name, 0, length)
+    def list
+      redis.lrange(name, 0, length)
     end
 
     def length
-      @redis.llen(name)
+      redis.llen(name)
     end
-   
+
     def clear
-      @redis.del(name)
+      redis.del(name)
     end
-    
+
     def enqueue(value)
-      if (@unique == false || !queued?(value))
-        @redis.rpush(name, value) 
+      if (unique == false || !queued?(value))
+        redis.rpush(name, value)
       else
         length
       end
     end
 
     def dequeue
-      @redis.lpop(name)
+      redis.lpop(name)
     end
 
     def queued?(value)
@@ -43,9 +45,9 @@ module Requeue
     def position(value)
       list.index(value)
     end
-    
+
     def remove(value)
-      @redis.lrem(name, 0, value)
+      redis.lrem(name, 0, value)
     end
 
     def owner
@@ -53,7 +55,7 @@ module Requeue
     end
 
     def first
-      @redis.lrange(name, 0, 1).first 
+      redis.lrange(name, 0, 1).first
     end
 
     def owned?
@@ -61,11 +63,11 @@ module Requeue
     end
 
     def steal(value)
-      @redis.lpush(name, value)
+      redis.lpush(name, value)
     end
-    
+
     def as_json
-      {queue: list, owner: owner, length: length}.to_json
+      { queue: list, owner: owner, length: length }
     end
   end
 end

--- a/lib/requeue/version.rb
+++ b/lib/requeue/version.rb
@@ -1,3 +1,3 @@
 module Requeue
-  VERSION = "0.7.3"
+  VERSION = "0.9.0"
 end


### PR DESCRIPTION
- make `as_json` conform with the standard (return a hash)
- code style improvements
- bump version to 0.9.0 — we seem to have lost some commit history for this repo (latest on rubygems.org is 0.8.0, but there's no diff in the code).

@lumoslabs/platform @azach 
